### PR TITLE
chore: migrate synth.py to bazel

### DIFF
--- a/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/package-info.java
+++ b/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * A client to Google Cloud Natural Language API.
+ * A client to Cloud Natural Language API.
  *
  * <p>The interfaces provided are listed below, along with usage samples.
  *

--- a/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/stub/GrpcLanguageServiceCallableFactory.java
+++ b/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/stub/GrpcLanguageServiceCallableFactory.java
@@ -36,7 +36,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC callable factory implementation for Google Cloud Natural Language API.
+ * gRPC callable factory implementation for Cloud Natural Language API.
  *
  * <p>This class is for advanced usage.
  */

--- a/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/stub/GrpcLanguageServiceStub.java
+++ b/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/stub/GrpcLanguageServiceStub.java
@@ -42,7 +42,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * gRPC stub implementation for Google Cloud Natural Language API.
+ * gRPC stub implementation for Cloud Natural Language API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/stub/LanguageServiceStub.java
+++ b/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/stub/LanguageServiceStub.java
@@ -34,7 +34,7 @@ import javax.annotation.Generated;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
- * Base stub class for Google Cloud Natural Language API.
+ * Base stub class for Cloud Natural Language API.
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */

--- a/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/stub/LanguageServiceStubSettings.java
+++ b/google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/stub/LanguageServiceStubSettings.java
@@ -87,7 +87,10 @@ import org.threeten.bp.Duration;
 public class LanguageServiceStubSettings extends StubSettings<LanguageServiceStubSettings> {
   /** The default scopes of the service. */
   private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES =
-      ImmutableList.<String>builder().add("https://www.googleapis.com/auth/cloud-platform").build();
+      ImmutableList.<String>builder()
+          .add("https://www.googleapis.com/auth/cloud-language")
+          .add("https://www.googleapis.com/auth/cloud-platform")
+          .build();
 
   private final UnaryCallSettings<AnalyzeSentimentRequest, AnalyzeSentimentResponse>
       analyzeSentimentSettings;

--- a/grpc-google-cloud-language-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-language-v1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.99.3 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/language/v1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-language-v1/src/main/java/com/google/cloud/language/v1/LanguageServiceGrpc.java
+++ b/grpc-google-cloud-language-v1/src/main/java/com/google/cloud/language/v1/LanguageServiceGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/language/v1/language_service.proto")
 public final class LanguageServiceGrpc {
 
@@ -40,30 +40,20 @@ public final class LanguageServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.language.v1.LanguageService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnalyzeSentimentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnalyzeSentimentRequest,
-          com.google.cloud.language.v1.AnalyzeSentimentResponse>
-      METHOD_ANALYZE_SENTIMENT = getAnalyzeSentimentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnalyzeSentimentRequest,
           com.google.cloud.language.v1.AnalyzeSentimentResponse>
       getAnalyzeSentimentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnalyzeSentiment",
+      requestType = com.google.cloud.language.v1.AnalyzeSentimentRequest.class,
+      responseType = com.google.cloud.language.v1.AnalyzeSentimentResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnalyzeSentimentRequest,
           com.google.cloud.language.v1.AnalyzeSentimentResponse>
       getAnalyzeSentimentMethod() {
-    return getAnalyzeSentimentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnalyzeSentimentRequest,
-          com.google.cloud.language.v1.AnalyzeSentimentResponse>
-      getAnalyzeSentimentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1.AnalyzeSentimentRequest,
             com.google.cloud.language.v1.AnalyzeSentimentResponse>
@@ -78,9 +68,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1.AnalyzeSentimentResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1.LanguageService", "AnalyzeSentiment"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "AnalyzeSentiment"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -99,30 +87,20 @@ public final class LanguageServiceGrpc {
     return getAnalyzeSentimentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnalyzeEntitiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnalyzeEntitiesRequest,
-          com.google.cloud.language.v1.AnalyzeEntitiesResponse>
-      METHOD_ANALYZE_ENTITIES = getAnalyzeEntitiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnalyzeEntitiesRequest,
           com.google.cloud.language.v1.AnalyzeEntitiesResponse>
       getAnalyzeEntitiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnalyzeEntities",
+      requestType = com.google.cloud.language.v1.AnalyzeEntitiesRequest.class,
+      responseType = com.google.cloud.language.v1.AnalyzeEntitiesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnalyzeEntitiesRequest,
           com.google.cloud.language.v1.AnalyzeEntitiesResponse>
       getAnalyzeEntitiesMethod() {
-    return getAnalyzeEntitiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnalyzeEntitiesRequest,
-          com.google.cloud.language.v1.AnalyzeEntitiesResponse>
-      getAnalyzeEntitiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1.AnalyzeEntitiesRequest,
             com.google.cloud.language.v1.AnalyzeEntitiesResponse>
@@ -137,9 +115,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1.AnalyzeEntitiesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1.LanguageService", "AnalyzeEntities"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "AnalyzeEntities"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -158,30 +134,20 @@ public final class LanguageServiceGrpc {
     return getAnalyzeEntitiesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnalyzeEntitySentimentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnalyzeEntitySentimentRequest,
-          com.google.cloud.language.v1.AnalyzeEntitySentimentResponse>
-      METHOD_ANALYZE_ENTITY_SENTIMENT = getAnalyzeEntitySentimentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnalyzeEntitySentimentRequest,
           com.google.cloud.language.v1.AnalyzeEntitySentimentResponse>
       getAnalyzeEntitySentimentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnalyzeEntitySentiment",
+      requestType = com.google.cloud.language.v1.AnalyzeEntitySentimentRequest.class,
+      responseType = com.google.cloud.language.v1.AnalyzeEntitySentimentResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnalyzeEntitySentimentRequest,
           com.google.cloud.language.v1.AnalyzeEntitySentimentResponse>
       getAnalyzeEntitySentimentMethod() {
-    return getAnalyzeEntitySentimentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnalyzeEntitySentimentRequest,
-          com.google.cloud.language.v1.AnalyzeEntitySentimentResponse>
-      getAnalyzeEntitySentimentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1.AnalyzeEntitySentimentRequest,
             com.google.cloud.language.v1.AnalyzeEntitySentimentResponse>
@@ -199,8 +165,7 @@ public final class LanguageServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1.LanguageService", "AnalyzeEntitySentiment"))
+                          generateFullMethodName(SERVICE_NAME, "AnalyzeEntitySentiment"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -219,30 +184,20 @@ public final class LanguageServiceGrpc {
     return getAnalyzeEntitySentimentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnalyzeSyntaxMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnalyzeSyntaxRequest,
-          com.google.cloud.language.v1.AnalyzeSyntaxResponse>
-      METHOD_ANALYZE_SYNTAX = getAnalyzeSyntaxMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnalyzeSyntaxRequest,
           com.google.cloud.language.v1.AnalyzeSyntaxResponse>
       getAnalyzeSyntaxMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnalyzeSyntax",
+      requestType = com.google.cloud.language.v1.AnalyzeSyntaxRequest.class,
+      responseType = com.google.cloud.language.v1.AnalyzeSyntaxResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnalyzeSyntaxRequest,
           com.google.cloud.language.v1.AnalyzeSyntaxResponse>
       getAnalyzeSyntaxMethod() {
-    return getAnalyzeSyntaxMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnalyzeSyntaxRequest,
-          com.google.cloud.language.v1.AnalyzeSyntaxResponse>
-      getAnalyzeSyntaxMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1.AnalyzeSyntaxRequest,
             com.google.cloud.language.v1.AnalyzeSyntaxResponse>
@@ -257,9 +212,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1.AnalyzeSyntaxResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1.LanguageService", "AnalyzeSyntax"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "AnalyzeSyntax"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -278,30 +231,20 @@ public final class LanguageServiceGrpc {
     return getAnalyzeSyntaxMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getClassifyTextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.ClassifyTextRequest,
-          com.google.cloud.language.v1.ClassifyTextResponse>
-      METHOD_CLASSIFY_TEXT = getClassifyTextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.ClassifyTextRequest,
           com.google.cloud.language.v1.ClassifyTextResponse>
       getClassifyTextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ClassifyText",
+      requestType = com.google.cloud.language.v1.ClassifyTextRequest.class,
+      responseType = com.google.cloud.language.v1.ClassifyTextResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.ClassifyTextRequest,
           com.google.cloud.language.v1.ClassifyTextResponse>
       getClassifyTextMethod() {
-    return getClassifyTextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.ClassifyTextRequest,
-          com.google.cloud.language.v1.ClassifyTextResponse>
-      getClassifyTextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1.ClassifyTextRequest,
             com.google.cloud.language.v1.ClassifyTextResponse>
@@ -316,9 +259,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1.ClassifyTextResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1.LanguageService", "ClassifyText"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ClassifyText"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -337,30 +278,20 @@ public final class LanguageServiceGrpc {
     return getClassifyTextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnnotateTextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnnotateTextRequest,
-          com.google.cloud.language.v1.AnnotateTextResponse>
-      METHOD_ANNOTATE_TEXT = getAnnotateTextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnnotateTextRequest,
           com.google.cloud.language.v1.AnnotateTextResponse>
       getAnnotateTextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnnotateText",
+      requestType = com.google.cloud.language.v1.AnnotateTextRequest.class,
+      responseType = com.google.cloud.language.v1.AnnotateTextResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1.AnnotateTextRequest,
           com.google.cloud.language.v1.AnnotateTextResponse>
       getAnnotateTextMethod() {
-    return getAnnotateTextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1.AnnotateTextRequest,
-          com.google.cloud.language.v1.AnnotateTextResponse>
-      getAnnotateTextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1.AnnotateTextRequest,
             com.google.cloud.language.v1.AnnotateTextResponse>
@@ -375,9 +306,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1.AnnotateTextResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1.LanguageService", "AnnotateText"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "AnnotateText"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -434,7 +363,7 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1.AnalyzeSentimentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnalyzeSentimentResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnalyzeSentimentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnalyzeSentimentMethod(), responseObserver);
     }
 
     /**
@@ -450,7 +379,7 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1.AnalyzeEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnalyzeEntitiesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnalyzeEntitiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnalyzeEntitiesMethod(), responseObserver);
     }
 
     /**
@@ -465,7 +394,7 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1.AnalyzeEntitySentimentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnalyzeEntitySentimentResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnalyzeEntitySentimentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnalyzeEntitySentimentMethod(), responseObserver);
     }
 
     /**
@@ -481,7 +410,7 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1.AnalyzeSyntaxRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnalyzeSyntaxResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnalyzeSyntaxMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnalyzeSyntaxMethod(), responseObserver);
     }
 
     /**
@@ -495,7 +424,7 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1.ClassifyTextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.ClassifyTextResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getClassifyTextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getClassifyTextMethod(), responseObserver);
     }
 
     /**
@@ -510,49 +439,49 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1.AnnotateTextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnnotateTextResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnnotateTextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnnotateTextMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getAnalyzeSentimentMethodHelper(),
+              getAnalyzeSentimentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1.AnalyzeSentimentRequest,
                       com.google.cloud.language.v1.AnalyzeSentimentResponse>(
                       this, METHODID_ANALYZE_SENTIMENT)))
           .addMethod(
-              getAnalyzeEntitiesMethodHelper(),
+              getAnalyzeEntitiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1.AnalyzeEntitiesRequest,
                       com.google.cloud.language.v1.AnalyzeEntitiesResponse>(
                       this, METHODID_ANALYZE_ENTITIES)))
           .addMethod(
-              getAnalyzeEntitySentimentMethodHelper(),
+              getAnalyzeEntitySentimentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1.AnalyzeEntitySentimentRequest,
                       com.google.cloud.language.v1.AnalyzeEntitySentimentResponse>(
                       this, METHODID_ANALYZE_ENTITY_SENTIMENT)))
           .addMethod(
-              getAnalyzeSyntaxMethodHelper(),
+              getAnalyzeSyntaxMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1.AnalyzeSyntaxRequest,
                       com.google.cloud.language.v1.AnalyzeSyntaxResponse>(
                       this, METHODID_ANALYZE_SYNTAX)))
           .addMethod(
-              getClassifyTextMethodHelper(),
+              getClassifyTextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1.ClassifyTextRequest,
                       com.google.cloud.language.v1.ClassifyTextResponse>(
                       this, METHODID_CLASSIFY_TEXT)))
           .addMethod(
-              getAnnotateTextMethodHelper(),
+              getAnnotateTextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1.AnnotateTextRequest,
@@ -597,7 +526,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnalyzeSentimentResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnalyzeSentimentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnalyzeSentimentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -616,7 +545,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnalyzeEntitiesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnalyzeEntitiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnalyzeEntitiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -634,7 +563,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnalyzeEntitySentimentResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnalyzeEntitySentimentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnalyzeEntitySentimentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -653,7 +582,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnalyzeSyntaxResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnalyzeSyntaxMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnalyzeSyntaxMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -670,7 +599,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.ClassifyTextResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getClassifyTextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getClassifyTextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -688,7 +617,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1.AnnotateTextResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnnotateTextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnnotateTextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -728,7 +657,7 @@ public final class LanguageServiceGrpc {
     public com.google.cloud.language.v1.AnalyzeSentimentResponse analyzeSentiment(
         com.google.cloud.language.v1.AnalyzeSentimentRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAnalyzeSentimentMethodHelper(), getCallOptions(), request);
+          getChannel(), getAnalyzeSentimentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -742,8 +671,7 @@ public final class LanguageServiceGrpc {
      */
     public com.google.cloud.language.v1.AnalyzeEntitiesResponse analyzeEntities(
         com.google.cloud.language.v1.AnalyzeEntitiesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getAnalyzeEntitiesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getAnalyzeEntitiesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -757,7 +685,7 @@ public final class LanguageServiceGrpc {
     public com.google.cloud.language.v1.AnalyzeEntitySentimentResponse analyzeEntitySentiment(
         com.google.cloud.language.v1.AnalyzeEntitySentimentRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAnalyzeEntitySentimentMethodHelper(), getCallOptions(), request);
+          getChannel(), getAnalyzeEntitySentimentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -771,8 +699,7 @@ public final class LanguageServiceGrpc {
      */
     public com.google.cloud.language.v1.AnalyzeSyntaxResponse analyzeSyntax(
         com.google.cloud.language.v1.AnalyzeSyntaxRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getAnalyzeSyntaxMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getAnalyzeSyntaxMethod(), getCallOptions(), request);
     }
 
     /**
@@ -784,8 +711,7 @@ public final class LanguageServiceGrpc {
      */
     public com.google.cloud.language.v1.ClassifyTextResponse classifyText(
         com.google.cloud.language.v1.ClassifyTextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getClassifyTextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getClassifyTextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -798,8 +724,7 @@ public final class LanguageServiceGrpc {
      */
     public com.google.cloud.language.v1.AnnotateTextResponse annotateText(
         com.google.cloud.language.v1.AnnotateTextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getAnnotateTextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getAnnotateTextMethod(), getCallOptions(), request);
     }
   }
 
@@ -838,7 +763,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1.AnalyzeSentimentResponse>
         analyzeSentiment(com.google.cloud.language.v1.AnalyzeSentimentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnalyzeSentimentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnalyzeSentimentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -854,7 +779,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1.AnalyzeEntitiesResponse>
         analyzeEntities(com.google.cloud.language.v1.AnalyzeEntitiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnalyzeEntitiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnalyzeEntitiesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -869,7 +794,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1.AnalyzeEntitySentimentResponse>
         analyzeEntitySentiment(com.google.cloud.language.v1.AnalyzeEntitySentimentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnalyzeEntitySentimentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnalyzeEntitySentimentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -885,7 +810,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1.AnalyzeSyntaxResponse>
         analyzeSyntax(com.google.cloud.language.v1.AnalyzeSyntaxRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnalyzeSyntaxMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnalyzeSyntaxMethod(), getCallOptions()), request);
     }
 
     /**
@@ -899,7 +824,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1.ClassifyTextResponse>
         classifyText(com.google.cloud.language.v1.ClassifyTextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getClassifyTextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getClassifyTextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -914,7 +839,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1.AnnotateTextResponse>
         annotateText(com.google.cloud.language.v1.AnnotateTextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnnotateTextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnnotateTextMethod(), getCallOptions()), request);
     }
   }
 
@@ -1043,12 +968,12 @@ public final class LanguageServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new LanguageServiceFileDescriptorSupplier())
-                      .addMethod(getAnalyzeSentimentMethodHelper())
-                      .addMethod(getAnalyzeEntitiesMethodHelper())
-                      .addMethod(getAnalyzeEntitySentimentMethodHelper())
-                      .addMethod(getAnalyzeSyntaxMethodHelper())
-                      .addMethod(getClassifyTextMethodHelper())
-                      .addMethod(getAnnotateTextMethodHelper())
+                      .addMethod(getAnalyzeSentimentMethod())
+                      .addMethod(getAnalyzeEntitiesMethod())
+                      .addMethod(getAnalyzeEntitySentimentMethod())
+                      .addMethod(getAnalyzeSyntaxMethod())
+                      .addMethod(getClassifyTextMethod())
+                      .addMethod(getAnnotateTextMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-language-v1beta2/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-language-v1beta2/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.99.3 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/language/v1beta2/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-language-v1beta2/src/main/java/com/google/cloud/language/v1beta2/LanguageServiceGrpc.java
+++ b/grpc-google-cloud-language-v1beta2/src/main/java/com/google/cloud/language/v1beta2/LanguageServiceGrpc.java
@@ -31,7 +31,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/language/v1beta2/language_service.proto")
 public final class LanguageServiceGrpc {
 
@@ -40,30 +40,20 @@ public final class LanguageServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.language.v1beta2.LanguageService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnalyzeSentimentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnalyzeSentimentRequest,
-          com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>
-      METHOD_ANALYZE_SENTIMENT = getAnalyzeSentimentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnalyzeSentimentRequest,
           com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>
       getAnalyzeSentimentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnalyzeSentiment",
+      requestType = com.google.cloud.language.v1beta2.AnalyzeSentimentRequest.class,
+      responseType = com.google.cloud.language.v1beta2.AnalyzeSentimentResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnalyzeSentimentRequest,
           com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>
       getAnalyzeSentimentMethod() {
-    return getAnalyzeSentimentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnalyzeSentimentRequest,
-          com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>
-      getAnalyzeSentimentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1beta2.AnalyzeSentimentRequest,
             com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>
@@ -78,9 +68,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1beta2.LanguageService", "AnalyzeSentiment"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "AnalyzeSentiment"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -99,30 +87,20 @@ public final class LanguageServiceGrpc {
     return getAnalyzeSentimentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnalyzeEntitiesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest,
-          com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>
-      METHOD_ANALYZE_ENTITIES = getAnalyzeEntitiesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest,
           com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>
       getAnalyzeEntitiesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnalyzeEntities",
+      requestType = com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest.class,
+      responseType = com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest,
           com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>
       getAnalyzeEntitiesMethod() {
-    return getAnalyzeEntitiesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest,
-          com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>
-      getAnalyzeEntitiesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest,
             com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>
@@ -137,9 +115,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1beta2.LanguageService", "AnalyzeEntities"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "AnalyzeEntities"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -158,30 +134,20 @@ public final class LanguageServiceGrpc {
     return getAnalyzeEntitiesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnalyzeEntitySentimentMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnalyzeEntitySentimentRequest,
-          com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse>
-      METHOD_ANALYZE_ENTITY_SENTIMENT = getAnalyzeEntitySentimentMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnalyzeEntitySentimentRequest,
           com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse>
       getAnalyzeEntitySentimentMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnalyzeEntitySentiment",
+      requestType = com.google.cloud.language.v1beta2.AnalyzeEntitySentimentRequest.class,
+      responseType = com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnalyzeEntitySentimentRequest,
           com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse>
       getAnalyzeEntitySentimentMethod() {
-    return getAnalyzeEntitySentimentMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnalyzeEntitySentimentRequest,
-          com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse>
-      getAnalyzeEntitySentimentMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1beta2.AnalyzeEntitySentimentRequest,
             com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse>
@@ -199,9 +165,7 @@ public final class LanguageServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1beta2.LanguageService",
-                              "AnalyzeEntitySentiment"))
+                          generateFullMethodName(SERVICE_NAME, "AnalyzeEntitySentiment"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -220,30 +184,20 @@ public final class LanguageServiceGrpc {
     return getAnalyzeEntitySentimentMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnalyzeSyntaxMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest,
-          com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>
-      METHOD_ANALYZE_SYNTAX = getAnalyzeSyntaxMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest,
           com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>
       getAnalyzeSyntaxMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnalyzeSyntax",
+      requestType = com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest.class,
+      responseType = com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest,
           com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>
       getAnalyzeSyntaxMethod() {
-    return getAnalyzeSyntaxMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest,
-          com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>
-      getAnalyzeSyntaxMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest,
             com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>
@@ -258,9 +212,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1beta2.LanguageService", "AnalyzeSyntax"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "AnalyzeSyntax"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -279,30 +231,20 @@ public final class LanguageServiceGrpc {
     return getAnalyzeSyntaxMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getClassifyTextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.ClassifyTextRequest,
-          com.google.cloud.language.v1beta2.ClassifyTextResponse>
-      METHOD_CLASSIFY_TEXT = getClassifyTextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.ClassifyTextRequest,
           com.google.cloud.language.v1beta2.ClassifyTextResponse>
       getClassifyTextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ClassifyText",
+      requestType = com.google.cloud.language.v1beta2.ClassifyTextRequest.class,
+      responseType = com.google.cloud.language.v1beta2.ClassifyTextResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.ClassifyTextRequest,
           com.google.cloud.language.v1beta2.ClassifyTextResponse>
       getClassifyTextMethod() {
-    return getClassifyTextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.ClassifyTextRequest,
-          com.google.cloud.language.v1beta2.ClassifyTextResponse>
-      getClassifyTextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1beta2.ClassifyTextRequest,
             com.google.cloud.language.v1beta2.ClassifyTextResponse>
@@ -317,9 +259,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1beta2.ClassifyTextResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1beta2.LanguageService", "ClassifyText"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ClassifyText"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -338,30 +278,20 @@ public final class LanguageServiceGrpc {
     return getClassifyTextMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getAnnotateTextMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnnotateTextRequest,
-          com.google.cloud.language.v1beta2.AnnotateTextResponse>
-      METHOD_ANNOTATE_TEXT = getAnnotateTextMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnnotateTextRequest,
           com.google.cloud.language.v1beta2.AnnotateTextResponse>
       getAnnotateTextMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "AnnotateText",
+      requestType = com.google.cloud.language.v1beta2.AnnotateTextRequest.class,
+      responseType = com.google.cloud.language.v1beta2.AnnotateTextResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.language.v1beta2.AnnotateTextRequest,
           com.google.cloud.language.v1beta2.AnnotateTextResponse>
       getAnnotateTextMethod() {
-    return getAnnotateTextMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.language.v1beta2.AnnotateTextRequest,
-          com.google.cloud.language.v1beta2.AnnotateTextResponse>
-      getAnnotateTextMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.language.v1beta2.AnnotateTextRequest,
             com.google.cloud.language.v1beta2.AnnotateTextResponse>
@@ -376,9 +306,7 @@ public final class LanguageServiceGrpc {
                           com.google.cloud.language.v1beta2.AnnotateTextResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.language.v1beta2.LanguageService", "AnnotateText"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "AnnotateText"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -435,7 +363,7 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1beta2.AnalyzeSentimentRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnalyzeSentimentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnalyzeSentimentMethod(), responseObserver);
     }
 
     /**
@@ -451,7 +379,7 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnalyzeEntitiesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnalyzeEntitiesMethod(), responseObserver);
     }
 
     /**
@@ -467,7 +395,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<
                 com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnalyzeEntitySentimentMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnalyzeEntitySentimentMethod(), responseObserver);
     }
 
     /**
@@ -483,7 +411,7 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnalyzeSyntaxMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnalyzeSyntaxMethod(), responseObserver);
     }
 
     /**
@@ -497,7 +425,7 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1beta2.ClassifyTextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.ClassifyTextResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getClassifyTextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getClassifyTextMethod(), responseObserver);
     }
 
     /**
@@ -512,49 +440,49 @@ public final class LanguageServiceGrpc {
         com.google.cloud.language.v1beta2.AnnotateTextRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.AnnotateTextResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getAnnotateTextMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getAnnotateTextMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getAnalyzeSentimentMethodHelper(),
+              getAnalyzeSentimentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1beta2.AnalyzeSentimentRequest,
                       com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>(
                       this, METHODID_ANALYZE_SENTIMENT)))
           .addMethod(
-              getAnalyzeEntitiesMethodHelper(),
+              getAnalyzeEntitiesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest,
                       com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>(
                       this, METHODID_ANALYZE_ENTITIES)))
           .addMethod(
-              getAnalyzeEntitySentimentMethodHelper(),
+              getAnalyzeEntitySentimentMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1beta2.AnalyzeEntitySentimentRequest,
                       com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse>(
                       this, METHODID_ANALYZE_ENTITY_SENTIMENT)))
           .addMethod(
-              getAnalyzeSyntaxMethodHelper(),
+              getAnalyzeSyntaxMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest,
                       com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>(
                       this, METHODID_ANALYZE_SYNTAX)))
           .addMethod(
-              getClassifyTextMethodHelper(),
+              getClassifyTextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1beta2.ClassifyTextRequest,
                       com.google.cloud.language.v1beta2.ClassifyTextResponse>(
                       this, METHODID_CLASSIFY_TEXT)))
           .addMethod(
-              getAnnotateTextMethodHelper(),
+              getAnnotateTextMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.language.v1beta2.AnnotateTextRequest,
@@ -599,7 +527,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnalyzeSentimentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnalyzeSentimentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -618,7 +546,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnalyzeEntitiesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnalyzeEntitiesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -637,7 +565,7 @@ public final class LanguageServiceGrpc {
                 com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnalyzeEntitySentimentMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnalyzeEntitySentimentMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -656,7 +584,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnalyzeSyntaxMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnalyzeSyntaxMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -673,7 +601,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.ClassifyTextResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getClassifyTextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getClassifyTextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -691,7 +619,7 @@ public final class LanguageServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.language.v1beta2.AnnotateTextResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getAnnotateTextMethodHelper(), getCallOptions()),
+          getChannel().newCall(getAnnotateTextMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -731,7 +659,7 @@ public final class LanguageServiceGrpc {
     public com.google.cloud.language.v1beta2.AnalyzeSentimentResponse analyzeSentiment(
         com.google.cloud.language.v1beta2.AnalyzeSentimentRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAnalyzeSentimentMethodHelper(), getCallOptions(), request);
+          getChannel(), getAnalyzeSentimentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -745,8 +673,7 @@ public final class LanguageServiceGrpc {
      */
     public com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse analyzeEntities(
         com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getAnalyzeEntitiesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getAnalyzeEntitiesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -760,7 +687,7 @@ public final class LanguageServiceGrpc {
     public com.google.cloud.language.v1beta2.AnalyzeEntitySentimentResponse analyzeEntitySentiment(
         com.google.cloud.language.v1beta2.AnalyzeEntitySentimentRequest request) {
       return blockingUnaryCall(
-          getChannel(), getAnalyzeEntitySentimentMethodHelper(), getCallOptions(), request);
+          getChannel(), getAnalyzeEntitySentimentMethod(), getCallOptions(), request);
     }
 
     /**
@@ -774,8 +701,7 @@ public final class LanguageServiceGrpc {
      */
     public com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse analyzeSyntax(
         com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getAnalyzeSyntaxMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getAnalyzeSyntaxMethod(), getCallOptions(), request);
     }
 
     /**
@@ -787,8 +713,7 @@ public final class LanguageServiceGrpc {
      */
     public com.google.cloud.language.v1beta2.ClassifyTextResponse classifyText(
         com.google.cloud.language.v1beta2.ClassifyTextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getClassifyTextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getClassifyTextMethod(), getCallOptions(), request);
     }
 
     /**
@@ -801,8 +726,7 @@ public final class LanguageServiceGrpc {
      */
     public com.google.cloud.language.v1beta2.AnnotateTextResponse annotateText(
         com.google.cloud.language.v1beta2.AnnotateTextRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getAnnotateTextMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getAnnotateTextMethod(), getCallOptions(), request);
     }
   }
 
@@ -841,7 +765,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1beta2.AnalyzeSentimentResponse>
         analyzeSentiment(com.google.cloud.language.v1beta2.AnalyzeSentimentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnalyzeSentimentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnalyzeSentimentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -857,7 +781,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1beta2.AnalyzeEntitiesResponse>
         analyzeEntities(com.google.cloud.language.v1beta2.AnalyzeEntitiesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnalyzeEntitiesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnalyzeEntitiesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -873,7 +797,7 @@ public final class LanguageServiceGrpc {
         analyzeEntitySentiment(
             com.google.cloud.language.v1beta2.AnalyzeEntitySentimentRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnalyzeEntitySentimentMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnalyzeEntitySentimentMethod(), getCallOptions()), request);
     }
 
     /**
@@ -889,7 +813,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1beta2.AnalyzeSyntaxResponse>
         analyzeSyntax(com.google.cloud.language.v1beta2.AnalyzeSyntaxRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnalyzeSyntaxMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnalyzeSyntaxMethod(), getCallOptions()), request);
     }
 
     /**
@@ -903,7 +827,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1beta2.ClassifyTextResponse>
         classifyText(com.google.cloud.language.v1beta2.ClassifyTextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getClassifyTextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getClassifyTextMethod(), getCallOptions()), request);
     }
 
     /**
@@ -918,7 +842,7 @@ public final class LanguageServiceGrpc {
             com.google.cloud.language.v1beta2.AnnotateTextResponse>
         annotateText(com.google.cloud.language.v1beta2.AnnotateTextRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getAnnotateTextMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getAnnotateTextMethod(), getCallOptions()), request);
     }
   }
 
@@ -1049,12 +973,12 @@ public final class LanguageServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new LanguageServiceFileDescriptorSupplier())
-                      .addMethod(getAnalyzeSentimentMethodHelper())
-                      .addMethod(getAnalyzeEntitiesMethodHelper())
-                      .addMethod(getAnalyzeEntitySentimentMethodHelper())
-                      .addMethod(getAnalyzeSyntaxMethodHelper())
-                      .addMethod(getClassifyTextMethodHelper())
-                      .addMethod(getAnnotateTextMethodHelper())
+                      .addMethod(getAnalyzeSentimentMethod())
+                      .addMethod(getAnalyzeEntitiesMethod())
+                      .addMethod(getAnalyzeEntitySentimentMethod())
+                      .addMethod(getAnalyzeSyntaxMethod())
+                      .addMethod(getClassifyTextMethod())
+                      .addMethod(getAnnotateTextMethod())
                       .build();
         }
       }

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,20 +1,21 @@
 {
-  "updateTime": "2020-02-24T22:58:13.934378Z",
+  "updateTime": "2020-03-10T17:08:24.248213Z",
   "sources": [
     {
-      "generator": {
-        "name": "artman",
-        "version": "0.45.1",
-        "dockerImage": "googleapis/artman@sha256:36956ca6a4dc70a59de5d5d0fd35061b050bb56884516f0898f46d8220f25738"
+      "git": {
+        "name": "googleapis",
+        "remote": "https://github.com/googleapis/googleapis.git",
+        "sha": "365c029b8cdb63f7751b92ab490f1976e616105c",
+        "internalRef": "300038469"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "1e47e676cddbbd8d93f19ba0665af15b5532417e",
-        "internalRef": "296901854",
-        "log": "1e47e676cddbbd8d93f19ba0665af15b5532417e\nFix: Restore a method signature for UpdateCluster\n\nPiperOrigin-RevId: 296901854\n\n"
+        "sha": "365c029b8cdb63f7751b92ab490f1976e616105c",
+        "internalRef": "300038469",
+        "log": "365c029b8cdb63f7751b92ab490f1976e616105c\nAdd CC targets to the kms protos.\n\nThese are needed by go/tink.\n\nPiperOrigin-RevId: 300038469\n\n4ba9aa8a4a1413b88dca5a8fa931824ee9c284e6\nExpose logo recognition API proto for GA.\n\nPiperOrigin-RevId: 299971671\n\n1c9fc2c9e03dadf15f16b1c4f570955bdcebe00e\nAdding ruby_package option to accessapproval.proto for the Ruby client libraries generation.\n\nPiperOrigin-RevId: 299955924\n\n1cc6f0a7bfb147e6f2ede911d9b01e7a9923b719\nbuild(google/maps/routes): generate api clients\n\nPiperOrigin-RevId: 299955905\n\n29a47c965aac79e3fe8e3314482ca0b5967680f0\nIncrease timeout to 1hr for method `dropRange` in bigtable/admin/v2, which is\nsynced with the timeout setting in gapic_yaml.\n\nPiperOrigin-RevId: 299917154\n\n8f631c4c70a60a9c7da3749511ee4ad432b62898\nbuild(google/maps/roads/v1op): move go to monorepo pattern\n\nPiperOrigin-RevId: 299885195\n\nd66816518844ebbf63504c9e8dfc7133921dd2cd\nbuild(google/maps/roads/v1op): Add bazel build files to generate clients.\n\nPiperOrigin-RevId: 299851148\n\naf7dff701fabe029672168649c62356cf1bb43d0\nAdd LogPlayerReports and LogImpressions to Playable Locations service\n\nPiperOrigin-RevId: 299724050\n\nb6927fca808f38df32a642c560082f5bf6538ced\nUpdate BigQuery Connection API v1beta1 proto: added credential to CloudSqlProperties.\n\nPiperOrigin-RevId: 299503150\n\n91e1fb5ef9829c0c7a64bfa5bde330e6ed594378\nchore: update protobuf (protoc) version to 3.11.2\n\nPiperOrigin-RevId: 299404145\n\n30e36b4bee6749c4799f4fc1a51cc8f058ba167d\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 299399890\n\nffbb493674099f265693872ae250711b2238090c\nfeat: cloudbuild/v1 add new fields and annotate OUTPUT_OUT fields.\n\nPiperOrigin-RevId: 299397780\n\nbc973a15818e00c19e121959832676e9b7607456\nbazel: Fix broken common  dependency\n\nPiperOrigin-RevId: 299397431\n\n71094a343e3b962e744aa49eb9338219537474e4\nchore: bigtable/admin/v2 publish retry config\n\nPiperOrigin-RevId: 299391875\n\n8f488efd7bda33885cb674ddd023b3678c40bd82\nfeat: Migrate logging to GAPIC v2; release new features.\n\nIMPORTANT: This is a breaking change for client libraries\nin all languages.\n\nCommitter: @lukesneeringer, @jskeet\nPiperOrigin-RevId: 299370279\n\n007605bf9ad3a1fd775014ebefbf7f1e6b31ee71\nUpdate API for bigqueryreservation v1beta1.\n- Adds flex capacity commitment plan to CapacityCommitment.\n- Adds methods for getting and updating BiReservations.\n- Adds methods for updating/splitting/merging CapacityCommitments.\n\nPiperOrigin-RevId: 299368059\n\nf0b581b5bdf803e45201ecdb3688b60e381628a8\nfix: recommendationengine/v1beta1 update some comments\n\nPiperOrigin-RevId: 299181282\n\n10e9a0a833dc85ff8f05b2c67ebe5ac785fe04ff\nbuild: add generated BUILD file for Routes Preferred API\n\nPiperOrigin-RevId: 299164808\n\n86738c956a8238d7c77f729be78b0ed887a6c913\npublish v1p1beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299152383\n\n73d9f2ad4591de45c2e1f352bc99d70cbd2a6d95\npublish v1: update with absolute address in comments\n\nPiperOrigin-RevId: 299147194\n\nd2158f24cb77b0b0ccfe68af784c6a628705e3c6\npublish v1beta2: update with absolute address in comments\n\nPiperOrigin-RevId: 299147086\n\n7fca61292c11b4cd5b352cee1a50bf88819dd63b\npublish v1p2beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146903\n\n583b7321624736e2c490e328f4b1957335779295\npublish v1p3beta1: update with absolute address in comments\n\nPiperOrigin-RevId: 299146674\n\n638253bf86d1ce1c314108a089b7351440c2f0bf\nfix: add java_multiple_files option for automl text_sentiment.proto\n\nPiperOrigin-RevId: 298971070\n\n373d655703bf914fb8b0b1cc4071d772bac0e0d1\nUpdate Recs AI Beta public bazel file\n\nPiperOrigin-RevId: 298961623\n\ndcc5d00fc8a8d8b56f16194d7c682027b2c66a3b\nfix: add java_multiple_files option for automl classification.proto\n\nPiperOrigin-RevId: 298953301\n\na3f791827266f3496a6a5201d58adc4bb265c2a3\nchore: automl/v1 publish annotations and retry config\n\nPiperOrigin-RevId: 298942178\n\n01c681586d8d6dbd60155289b587aee678530bd9\nMark return_immediately in PullRequest deprecated.\n\nPiperOrigin-RevId: 298893281\n\nc9f5e9c4bfed54bbd09227e990e7bded5f90f31c\nRemove out of date documentation for predicate support on the Storage API\n\nPiperOrigin-RevId: 298883309\n\nfd5b3b8238d783b04692a113ffe07c0363f5de0f\ngenerate webrisk v1 proto\n\nPiperOrigin-RevId: 298847934\n\n541b1ded4abadcc38e8178680b0677f65594ea6f\nUpdate cloud asset api v1p4beta1.\n\nPiperOrigin-RevId: 298686266\n\nc0d171acecb4f5b0bfd2c4ca34fc54716574e300\n  Updated to include the Notification v1 API.\n\nPiperOrigin-RevId: 298652775\n\n2346a9186c0bff2c9cc439f2459d558068637e05\nAdd Service Directory v1beta1 protos and configs\n\nPiperOrigin-RevId: 298625638\n\na78ed801b82a5c6d9c5368e24b1412212e541bb7\nPublishing v3 protos and configs.\n\nPiperOrigin-RevId: 298607357\n\n4a180bfff8a21645b3a935c2756e8d6ab18a74e0\nautoml/v1beta1 publish proto updates\n\nPiperOrigin-RevId: 298484782\n\n6de6e938b7df1cd62396563a067334abeedb9676\nchore: use the latest gapic-generator and protoc-java-resource-name-plugin in Bazel workspace.\n\nPiperOrigin-RevId: 298474513\n\n244ab2b83a82076a1fa7be63b7e0671af73f5c02\nAdds service config definition for bigqueryreservation v1\n\nPiperOrigin-RevId: 298455048\n\n83c6f84035ee0f80eaa44d8b688a010461cc4080\nUpdate google/api/auth.proto to make AuthProvider to have JwtLocation\n\nPiperOrigin-RevId: 297918498\n\ne9e90a787703ec5d388902e2cb796aaed3a385b4\nDialogflow weekly v2/v2beta1 library update:\n  - adding get validation result\n  - adding field mask override control for output audio config\nImportant updates are also posted at:\nhttps://cloud.google.com/dialogflow/docs/release-notes\n\nPiperOrigin-RevId: 297671458\n\n1a2b05cc3541a5f7714529c665aecc3ea042c646\nAdding .yaml and .json config files.\n\nPiperOrigin-RevId: 297570622\n\ndfe1cf7be44dee31d78f78e485d8c95430981d6e\nPublish `QueryOptions` proto.\n\nIntroduced a `query_options` input in `ExecuteSqlRequest`.\n\nPiperOrigin-RevId: 297497710\n\ndafc905f71e5d46f500b41ed715aad585be062c3\npubsub: revert pull init_rpc_timeout & max_rpc_timeout back to 25 seconds and reset multiplier to 1.0\n\nPiperOrigin-RevId: 297486523\n\nf077632ba7fee588922d9e8717ee272039be126d\nfirestore: add update_transform\n\nPiperOrigin-RevId: 297405063\n\n0aba1900ffef672ec5f0da677cf590ee5686e13b\ncluster: use square brace for cross-reference\n\nPiperOrigin-RevId: 297204568\n\n5dac2da18f6325cbaed54603c43f0667ecd50247\nRestore retry params in gapic config because securitycenter has non-standard default retry params.\nRestore a few retry codes for some idempotent methods.\n\nPiperOrigin-RevId: 297196720\n\n1eb61455530252bba8b2c8d4bc9832960e5a56f6\npubsub: v1 replace IAM HTTP rules\n\nPiperOrigin-RevId: 297188590\n\n80b2d25f8d43d9d47024ff06ead7f7166548a7ba\nDialogflow weekly v2/v2beta1 library update:\n  - updates to mega agent api\n  - adding field mask override control for output audio config\nImportant updates are also posted at:\nhttps://cloud.google.com/dialogflow/docs/release-notes\n\nPiperOrigin-RevId: 297187629\n\n0b1876b35e98f560f9c9ca9797955f020238a092\nUse an older version of protoc-docs-plugin that is compatible with the specified gapic-generator and protobuf versions.\n\nprotoc-docs-plugin >=0.4.0 (see commit https://github.com/googleapis/protoc-docs-plugin/commit/979f03ede6678c487337f3d7e88bae58df5207af) is incompatible with protobuf 3.9.1.\n\nPiperOrigin-RevId: 296986742\n\n"
       }
     },
     {
@@ -32,8 +33,7 @@
         "apiName": "language",
         "apiVersion": "v1",
         "language": "java",
-        "generator": "gapic",
-        "config": "google/cloud/language/artman_language_v1.yaml"
+        "generator": "bazel"
       }
     },
     {
@@ -42,8 +42,7 @@
         "apiName": "language",
         "apiVersion": "v1beta2",
         "language": "java",
-        "generator": "gapic",
-        "config": "google/cloud/language/artman_language_v1beta2.yaml"
+        "generator": "bazel"
       }
     }
   ]

--- a/synth.py
+++ b/synth.py
@@ -14,37 +14,18 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
 
 service = 'language'
 versions = ['v1', 'v1beta2']
-config_pattern = '/google/cloud/language/artman_language_{version}.yaml'
 
 for version in versions:
-    library = gapic.java_library(
-        service=service,
-        version=version,
-        config_path=config_pattern.format(version=version),
-        artman_output_name='')
+  library = java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
+  )
 
-    package_name = f'com.google.cloud.{service}.{version}'
-    java.fix_proto_headers(library / f'proto-google-cloud-{service}-{version}')
-    java.fix_grpc_headers(library / f'grpc-google-cloud-{service}-{version}', package_name)
-
-    s.copy(library / f'gapic-google-cloud-{service}-{version}/src', f'google-cloud-{service}/src')
-    s.copy(library / f'grpc-google-cloud-{service}-{version}/src', f'grpc-google-cloud-{service}-{version}/src')
-    s.copy(library / f'proto-google-cloud-{service}-{version}/src', f'proto-google-cloud-{service}-{version}/src')
-
-    java.format_code(f'google-cloud-{service}/src')
-    java.format_code(f'grpc-google-cloud-{service}-{version}/src')
-    java.format_code(f'proto-google-cloud-{service}-{version}/src')
-
-common_templates = gcp.CommonTemplates()
-templates = common_templates.java_library()
-s.copy(templates, excludes=[
+java.common_templates(excludes=[
     'README.md',
 ])


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for context and/or discussion)